### PR TITLE
Update dbus-solarlog-json.py

### DIFF
--- a/dbus-solarlog-json.py
+++ b/dbus-solarlog-json.py
@@ -7,6 +7,7 @@ import logging
 import sys
 import os
 import sys
+import csv
 if sys.version_info.major == 2:
     import gobject
 else:


### PR DESCRIPTION
Will fix the error in current.log:

File "/data/dbus-solarlog-json/dbus-solarlog-json.py", line 177, in _update csv_reader = csv.reader(csv_file, delimiter=';') NameError: name 'csv' is not defined

you did not import csv